### PR TITLE
Fix typo in launch parameter for Hokuyo

### DIFF
--- a/launch/core/pioneer3.launch
+++ b/launch/core/pioneer3.launch
@@ -1,6 +1,6 @@
 <launch>
    <include file="$(find pioneer_outdoor)/launch/core/core.launch">
-      <arg name="hokoyu" value="1"/>
+      <arg name="hokuyo" value="1"/>
       <arg name="sick" value="0"/>
       <arg name="ahrs" value="1"/>
       <arg name="robot" value="1"/>


### PR DESCRIPTION
Because of this typo the Hokuyo laser node doesn't start on Pioneer-3 with pioneer_core command
